### PR TITLE
azhu - Adding Fixtures for UCSB organizations

### DIFF
--- a/frontend/src/fixtures/ucsbOrganizationFixtures.js
+++ b/frontend/src/fixtures/ucsbOrganizationFixtures.js
@@ -1,0 +1,24 @@
+const ucsbOrganizationFixtures = {
+    oneOrg: {
+        "orgCode": "SKY",
+        "orgTranslation": "Skydiving Club at UCSB",
+        "orgTranslationShort": "Skydiving Club",
+        "inactive": false
+    },
+    twoOrgs: [
+        {
+            "orgCode": "SKY",
+            "orgTranslation": "Skydiving Club at UCSB",
+            "orgTranslationShort": "Skydiving Club",
+            "inactive": false
+        },
+        {
+            "orgCode": "ZPR",
+            "orgTranslation": "Zeta Phi Rho",
+            "orgTranslationShort": "Zeta Phi Rho",
+            "inactive": true
+        }
+    ]
+}
+   
+export {ucsbOrganizationFixtures }; 


### PR DESCRIPTION
In this PR, we add fixtures for UCSB organizations. We have one for getting 1 singular organization (`?orgCode=<...>`) and another for getting multiple (`/all`)

Closes #18 