### PR TITLE
Sasha - "Create" page for HelpRequest

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -107,6 +107,7 @@ function App() {
            </>
          )
        }
+       {
           hasRole(currentUser, "ROLE_USER") && (
             <>
               <Route exact path="/articles" element={<ArticlesIndexPage />} />

--- a/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
+++ b/frontend/src/main/pages/HelpRequest/HelpRequestCreatePage.js
@@ -1,12 +1,53 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import HelpRequestForm from "main/components/HelpRequest/HelpRequestForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function HelpRequestCreatePage() {
+export default function HelpRequestCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
+  const objectToAxiosParams = (helpRequest) => ({
+    url: "/api/HelpRequest/post",
+    method: "POST",
+    params: {
+      requesterEmail: helpRequest.requesterEmail,
+      teamId: helpRequest.teamId,
+      tableOrBreakoutRoom: helpRequest.tableOrBreakoutRoom,
+      requestTime: helpRequest.requestTime,
+      explanation: helpRequest.explanation,
+      solved: helpRequest.solved
+
+    }
+  });
+
+  const onSuccess = (helpRequest) => {
+    toast(`New helpRequest Created - id: ${helpRequest.id} requesterEmail: ${helpRequest.requesterEmail}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/HelpRequest/all"]
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/HelpRequest" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New HelpRequest</h1>
+
+        <HelpRequestForm submitAction={onSubmit} />
+
       </div>
     </BasicLayout>
   )

--- a/frontend/src/stories/pages/HelpRequest/HelpRequestCreatePage.stories.js
+++ b/frontend/src/stories/pages/HelpRequest/HelpRequestCreatePage.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
+
+export default {
+    title: 'pages/HelpRequest/HelpRequestCreatePage',
+    component: HelpRequestCreatePage
+};
+
+const Template = () => <HelpRequestCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/HelpRequest/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
@@ -7,9 +7,9 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
-import { HelpRequestForm } from "main/components/HelpRequest/HelpRequestForm";
-import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
+//import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+//import { HelpRequestForm } from "main/components/HelpRequest/HelpRequestForm";
+//import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
 
 const mockToast = jest.fn();
 jest.mock('react-toastify', () => {

--- a/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/HelpRequest/HelpRequestCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
 import HelpRequestCreatePage from "main/pages/HelpRequest/HelpRequestCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -7,25 +7,67 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import { helpRequestFixtures } from "fixtures/helpRequestFixtures";
+import { HelpRequestForm } from "main/components/HelpRequest/HelpRequestForm";
+import HelpRequestEditPage from "main/pages/HelpRequest/HelpRequestEditPage";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("HelpRequestCreatePage tests", () => {
 
-    const axiosMock = new AxiosMockAdapter(axios);
+    const axiosMock =new AxiosMockAdapter(axios);
 
-    const setupUserOnly = () => {
+    beforeEach(() => {
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <HelpRequestCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
 
-        setupUserOnly();
-       
-        // act
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const helpRequest = {
+            id: 17,
+            requesterEmail: "blah@ucsb.edu",
+            teamId: "s23-7pm-4",
+            tableOrBreakoutRoom: "5",
+            requestTime: "2022-04-20T17:35",
+            explanation: "blah",
+            solved: false
+        };
+
+        axiosMock.onPost("/api/HelpRequest/post").reply( 202, helpRequest );
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -34,10 +76,44 @@ describe("HelpRequestCreatePage tests", () => {
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByTestId("HelpRequestForm-requesterEmail")).toBeInTheDocument();
+        });
+
+        const requesterEmailField = screen.getByTestId("HelpRequestForm-requesterEmail");
+        const teamIdField = screen.getByTestId("HelpRequestForm-teamId");
+        const tableOrBreakoutRoomField = screen.getByTestId("HelpRequestForm-tableOrBreakoutRoom");
+        const requestTimeField = screen.getByTestId("HelpRequestForm-requestTime");
+        const explanationField = screen.getByTestId("HelpRequestForm-explanation");
+        const solvedField = screen.getByTestId("HelpRequestForm-solved");
+        const submitButton = screen.getByTestId("HelpRequestForm-submit");
+
+        fireEvent.change(requesterEmailField, { target: { value: 'blah@ucsb.edu' } });
+        fireEvent.change(teamIdField, { target: { value: 's23-7pm-4' } });
+        fireEvent.change(tableOrBreakoutRoomField, { target: { value: '5' } });
+        fireEvent.change(requestTimeField, { target: { value: '2022-04-20T17:35' } });
+        fireEvent.change(explanationField, { target: { value: 'blah' } });
+        fireEvent.change(solvedField, { target: { value: false } });
+        
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+            "requesterEmail": "blah@ucsb.edu",
+            "teamId": "s23-7pm-4",
+            "tableOrBreakoutRoom": "5",
+            "requestTime": "2022-04-20T17:35",
+            "explanation": "blah",
+            "solved": "false"
+        });
+
+        expect(mockToast).toBeCalledWith("New helpRequest Created - id: 17 requesterEmail: blah@ucsb.edu");
+        expect(mockNavigate).toBeCalledWith({ "to": "/HelpRequest" });
     });
 
+
 });
-
-


### PR DESCRIPTION
In this PR, I have added a create page for HelpRequest. Here's how you can test it. When you navigate to "HelpRequest/create" on your deployment, you will see that the page should look something like this:
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-4/assets/146385625/2c1b649d-8b59-47c3-8338-7f920a63494e)
You can put in data, just make sure that it is valid! For the solved field, you can only type in 'true' for if it is solved, or 'false' for if it is not. If you put in anything else, the request will NOT be submitted.
After you click submit, you should see something like this: 
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-4/assets/146385625/c331eea0-7867-41eb-a2a7-80cd079219eb)
And we can verify the entry was put in by going to Swagger.
![image](https://github.com/ucsb-cs156-f23/team03-f23-7pm-4/assets/146385625/c7c1497b-9fff-44cc-bfdd-4382419874e3)

Try it out yourself, but it works.
Storybook: http://localhost:6006/?path=/story/components-helprequest-helprequestform--create
Create page: http://localhost:8080/HelpRequest/create
Closes: #49 